### PR TITLE
feat: expose ResponseBytes & RequestBytesUnread to AdditionalAttrs

### DIFF
--- a/options.go
+++ b/options.go
@@ -144,6 +144,9 @@ type LogAdditionalAttrsOptions struct {
 type LogDetails struct {
 	Request *http.Request
 	// Contains the request body if either Options.LogRequestBody or LogAdditionalAttrsOptions.IncludeRequestBody is true, otherwise it is empty.
-	RequestBody    string
-	ResponseStatus int
+	RequestBody string
+	// Contains the number of unread bytes from the request body if either Options.LogRequestBody or LogAdditionalAttrsOptions.IncludeRequestBody is true, otherwise it is 0.
+	RequestBytesUnread int64
+	ResponseStatus     int
+	ResponseBytes      int
 }


### PR DESCRIPTION
> [!NOTE]
> This PR assumes #68 is merged.  If #68 is not merged, the signature to `LogExtraAttrs` would need to change to pass this information through.  PR #68 introduces a non-breaking change that allows adding additional information moving forward without requiring a breaking change.

Adds passing `ResponseBytes` and `RequestBytesUnread` to `LogAdditionalAttrsOptions.AdditionalAttrs`.

Note - A similar thing can/should be done for RequestBytesRead assuming PR #67 is merged.

Resolves #63